### PR TITLE
Fix/usdz layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 USD to GLTF/GLB converter
 
-Current version `0.3.3`
+Current version `0.3.4`
 
 ## Requirements
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = usd2gltf
-version = 0.3.3
+version = 0.3.4
 author = Mike Lyndon
 author_email = work.mike@pm.me
 description = Convert USD to GLTF

--- a/src/usd2gltf/converter.py
+++ b/src/usd2gltf/converter.py
@@ -220,6 +220,8 @@ class Converter:
         for i, l in enumerate(self.stage.GetRootLayer().subLayerPaths):
             if "usdz" in l:
                 new_path = self.localize_zip(str(l))
+                self.stage = Usd.Stage.Open(new_path)
+                break
 
         self.FPS = self.stage.GetFramesPerSecond()
 

--- a/src/usd2gltf/converter.py
+++ b/src/usd2gltf/converter.py
@@ -215,8 +215,8 @@ class Converter:
 
         self.stage = stage
 
-        # TODO: Is this being used?
-        # Unzip all sublayers
+        # TODO: If there are multiple usdz files, we probably need to recreate the stage. 
+        # Unzip first sublayer that is a usdz file
         for i, l in enumerate(self.stage.GetRootLayer().GetLoadedLayers()):
             if "usdz" in l.realPath:
                 new_path = self.localize_zip(str(l.realPath))

--- a/src/usd2gltf/converter.py
+++ b/src/usd2gltf/converter.py
@@ -217,9 +217,9 @@ class Converter:
 
         # TODO: Is this being used?
         # Unzip all sublayers
-        for i, l in enumerate(self.stage.GetRootLayer().subLayerPaths):
-            if "usdz" in l:
-                new_path = self.localize_zip(str(l))
+        for i, l in enumerate(self.stage.GetRootLayer().GetLoadedLayers()):
+            if "usdz" in l.realPath:
+                new_path = self.localize_zip(str(l.realPath))
                 self.stage = Usd.Stage.Open(new_path)
                 break
 


### PR DESCRIPTION
The cli works for the most part with a usdz input path. But if this module is used as part of a workflow and the stage is passed to the converter instead of the path we need a way to handle any usdz files that exist as layers.
This is a quick and dirty solution. We check all loaded layers and return the first layer that contains a usdz path.
Ideally, we want to unzip all usdz paths and recreate the stage with the new references.